### PR TITLE
Improved GH workflows

### DIFF
--- a/.github/workflows/ansible-tasks.yaml
+++ b/.github/workflows/ansible-tasks.yaml
@@ -34,8 +34,18 @@ jobs:
           if [ -f requirements.txt ]; then
             pip install -r requirements.txt
           fi
+          if [ -f ansible-tasks/requirements.txt ]; then
+            pip install -r ansible-tasks/requirements.txt
+          fi
+
+      - name: Install OpenShift CLI tools
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          openshift-install: "${{secrets.OCP_CLIENT_VERSION}}"
+          oc: "${{secrets.OCP_CLIENT_VERSION}}"
 
       - name: Run ansible playbook
         run: |
-          export KUBECONFIG=ocp-artifact/auth/kubeconfig
+          cp ocp-artifact/auth/kubeconfig $GITHUB_WORKSPACE/kubeconfig
+          export KUBECONFIG=$GITHUB_WORKSPACE/kubeconfig
           ansible-playbook ansible-tasks/main.yaml

--- a/.github/workflows/ansible-tasks.yaml
+++ b/.github/workflows/ansible-tasks.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Download Artifacts from Cluster Deploy
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: Deploy.yaml
+          workflow: deploy.yaml
           name: ocp-artifact
           path: ocp-artifact
 

--- a/.github/workflows/ansible-tasks.yaml
+++ b/.github/workflows/ansible-tasks.yaml
@@ -1,0 +1,38 @@
+name: Ansible-Tasks
+on:
+  workflow_run:
+    workflows:
+      - Deploy
+    types:
+      - completed
+    branches:
+      - main
+      - master
+jobs:
+  Setup:
+    name: Run Ansible Playbook against new OCP4 cluster
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ocp4-ansible-roles external repo
+        uses: actions/checkout@v2
+        with:
+          repository: luiscachog/ocp4-ansible-roles
+          path: ansible-tasks
+
+      - name: Download Artifacts from Cluster Deploy
+        uses: actions/download-artifact@v2
+        with:
+          name: ocp-artifact
+          path: ocp-artifact
+
+      - name: Install Python Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+
+      - name: Run ansible playbook
+        run: |
+          export KUBECONFIG=ocp-artifact/auth/kubeconfig
+          ansible-playbook ansible-tasks/main.yaml

--- a/.github/workflows/ansible-tasks.yaml
+++ b/.github/workflows/ansible-tasks.yaml
@@ -25,7 +25,6 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: Deploy.yaml
-          workflow_conclusion: success
           name: ocp-artifact
           path: ocp-artifact
 

--- a/.github/workflows/ansible-tasks.yaml
+++ b/.github/workflows/ansible-tasks.yaml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - master
+  workflow_dispatch:
+
 jobs:
   Setup:
     name: Run Ansible Playbook against new OCP4 cluster
@@ -20,8 +22,10 @@ jobs:
           path: ansible-tasks
 
       - name: Download Artifacts from Cluster Deploy
-        uses: actions/download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: Deploy.yaml
+          workflow_conclusion: success
           name: ocp-artifact
           path: ocp-artifact
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,6 +5,8 @@ on:
       - 'main'
     paths:
       - 'deploy.md'
+  workflow_dispatch:
+
 jobs:
   Setup:
     name: Setup OpenShift Installer Binary

--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -5,6 +5,8 @@ on:
       - 'main'
     paths:
       - 'destroy.md'
+  workflow_dispatch:
+
 jobs:
   Setup:
     name: Setup OpenShift Installer Binary


### PR DESCRIPTION
Hello!

With this PR, I'm suggesting using the option `workflow_dispatch` to manually run the workflow that we want to run if needed.
Also, I added a new workflow `ansible-tasks` that runs all the ansible playbooks/roles from a remote repository, in this case, my repo, but we can use any repo.
The idea of these 2 changes is to decouple the workflows and run them on-demand.